### PR TITLE
Fix server start

### DIFF
--- a/packages/server/scripts/start.sh
+++ b/packages/server/scripts/start.sh
@@ -1,2 +1,2 @@
-yarn run concurrently "yarn codegen --watch" \
-    "yarn run nodemon --ext ts,graphql,json --exec 'ts-node' scripts/startDevServer"
+concurrently "codegen --watch" \
+    "nodemon --ext ts,graphql,json --exec 'ts-node' scripts/startDevServer"


### PR DESCRIPTION
Error running concurrently.

>$ yarn workspace server start
yarn workspace v1.17.3
yarn run v1.17.3
$ yarn run concurrently "yarn codegen --watch" \ "yarn run nodemon --ext ts,graphql,json --exec 'ts-node' scripts/startDevServer"
error Command "concurrently" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1

 In order to use the node_module dependency, `yarn run` needs to be removed from the script. This might not have been an issue if `concurrently` and `nodemon` (got error for that one too) were previously installed globally.